### PR TITLE
fix: issue creation and mention UX

### DIFF
--- a/app/api/v1/issues/route.ts
+++ b/app/api/v1/issues/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { Prisma } from "@prisma/client";
 
-import { apiSuccess } from "@/lib/api-response";
+import { apiError, apiSuccess } from "@/lib/api-response";
 import { getDatabaseEnvDiagnostics } from "@/lib/env";
 import { prisma } from "@/lib/prisma";
 import { createIssueSchema, issueQuerySchema } from "@/lib/schemas";
@@ -51,6 +51,19 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   return withAuthRoute(request, async (user) => {
     const body = await request.json();
+
+    if (!body?.title || !body?.projectId) {
+      return apiError("Invalid payload", 400);
+    }
+
+    if (
+      body.assigneeId !== undefined &&
+      body.assigneeId !== null &&
+      typeof body.assigneeId !== "string"
+    ) {
+      return apiError("Invalid payload", 400);
+    }
+
     const input = createIssueSchema.parse(body);
     const result = await createIssue(user, input);
 

--- a/components/dashboard/IssueModal.tsx
+++ b/components/dashboard/IssueModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
+import { useToast } from "@/components/providers/ToastProvider";
 import { Modal } from "@/components/ui/Modal";
 import {
   MAX_ISSUE_DESCRIPTION_LENGTH,
@@ -40,6 +41,13 @@ const initialState = {
   assigneeId: "",
 };
 
+const initialErrors = {
+  title: "",
+  description: "",
+  project: "",
+  assigneeId: "",
+};
+
 export function IssueModal({
   open,
   members,
@@ -48,7 +56,9 @@ export function IssueModal({
   onClose,
   onSubmit,
 }: IssueModalProps) {
+  const { pushToast } = useToast();
   const [formState, setFormState] = useState(initialState);
+  const [errors, setErrors] = useState(initialErrors);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const assignableMembers = members.filter(
     (member) => currentUserRole === "DEVELOPER" || member.projectRole !== "ADMIN",
@@ -57,6 +67,7 @@ export function IssueModal({
   useEffect(() => {
     if (open) {
       setFormState(initialState);
+      setErrors(initialErrors);
       setIsSubmitting(false);
     }
   }, [open]);
@@ -76,22 +87,49 @@ export function IssueModal({
         className="space-y-5"
         onSubmit={async (event) => {
           event.preventDefault();
+          const nextErrors = {
+            title: formState.title.trim() ? "" : "Title is required.",
+            description: formState.description.trim()
+              ? ""
+              : "Description is required.",
+            project: project?.id ? "" : "Select a project first.",
+            assigneeId:
+              !formState.assigneeId ||
+              assignableMembers.some((member) => member.id === formState.assigneeId)
+                ? ""
+                : "Select a valid assignee from this project.",
+          };
+
+          setErrors(nextErrors);
+
+          if (Object.values(nextErrors).some(Boolean) || !project?.id) {
+            return;
+          }
+
           setIsSubmitting(true);
 
           try {
-            if (!project) {
-              return;
-            }
-
             await onSubmit({
-              title: formState.title,
-              description: formState.description,
+              title: formState.title.trim(),
+              description: formState.description.trim(),
               priority: formState.priority,
               severity: formState.severity,
               projectId: project.id,
-              assigneeId: formState.assigneeId || undefined,
+              assigneeId:
+                typeof formState.assigneeId === "string" && formState.assigneeId
+                  ? formState.assigneeId
+                  : undefined,
             });
             onClose();
+          } catch (submitError) {
+            pushToast({
+              title: "Unable to create issue",
+              description:
+                submitError instanceof Error
+                  ? submitError.message
+                  : "Check the issue details and try again.",
+              tone: "error",
+            });
           } finally {
             setIsSubmitting(false);
           }
@@ -104,17 +142,27 @@ export function IssueModal({
           <p className="mt-2 text-sm font-medium text-slate-950">
             {project?.name ?? "Select a project first"}
           </p>
+          {errors.project ? (
+            <p className="mt-2 text-sm text-red-600">{errors.project}</p>
+          ) : null}
         </div>
 
         <div className="grid gap-5 md:grid-cols-2">
           <Input
+            error={errors.title}
             label="Title"
             maxLength={MAX_ISSUE_TITLE_LENGTH}
             onChange={(event) =>
-              setFormState((current) => ({
-                ...current,
-                title: event.target.value,
-              }))
+              {
+                setFormState((current) => ({
+                  ...current,
+                  title: event.target.value,
+                }));
+                setErrors((current) => ({
+                  ...current,
+                  title: "",
+                }));
+              }
             }
             placeholder="Example: Login redirect loops after refresh"
             value={formState.title}
@@ -125,10 +173,16 @@ export function IssueModal({
             <select
               className="h-11 rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-900 outline-none focus:border-[color:var(--color-primary)]"
               onChange={(event) =>
-                setFormState((current) => ({
-                  ...current,
-                  assigneeId: event.target.value,
-                }))
+                {
+                  setFormState((current) => ({
+                    ...current,
+                    assigneeId: event.target.value,
+                  }));
+                  setErrors((current) => ({
+                    ...current,
+                    assigneeId: "",
+                  }));
+                }
               }
               value={formState.assigneeId}
             >
@@ -139,6 +193,9 @@ export function IssueModal({
                 </option>
               ))}
             </select>
+            {errors.assigneeId ? (
+              <span className="text-xs text-red-600">{errors.assigneeId}</span>
+            ) : null}
             {currentUserRole !== "DEVELOPER" ? (
               <span className="text-xs text-slate-500">
                 Admin users cannot be assigned by Admin or QA accounts.
@@ -153,14 +210,23 @@ export function IssueModal({
             className="min-h-36 rounded-[24px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none focus:border-[color:var(--color-primary)] focus:ring-4 focus:ring-blue-100"
             maxLength={MAX_ISSUE_DESCRIPTION_LENGTH}
             onChange={(event) =>
-              setFormState((current) => ({
-                ...current,
-                description: event.target.value,
-              }))
+              {
+                setFormState((current) => ({
+                  ...current,
+                  description: event.target.value,
+                }));
+                setErrors((current) => ({
+                  ...current,
+                  description: "",
+                }));
+              }
             }
             placeholder="What happened, where it happened, and what the expected behavior should be."
             value={formState.description}
           />
+          {errors.description ? (
+            <span className="text-sm text-red-600">{errors.description}</span>
+          ) : null}
         </label>
 
         <div className="grid gap-5 md:grid-cols-2">

--- a/components/issues/CommentComposer.tsx
+++ b/components/issues/CommentComposer.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { Button } from "@/components/ui/Button";
 import { MAX_COMMENT_LENGTH } from "@/lib/constants";
+import {
+  COMMENT_MENTION_REGEX,
+  extractMentionUsernames,
+  findActiveMentionQuery,
+  replaceTrailingMention,
+} from "@/lib/comments";
+import type { ProjectMemberUserSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface CommentComposerProps {
@@ -15,6 +22,52 @@ interface CommentComposerProps {
   onCancel?: () => void;
   autoFocus?: boolean;
   className?: string;
+  teamMembers?: ProjectMemberUserSummary[];
+}
+
+function renderMentionPreview(
+  content: string,
+  validMentions: ReadonlySet<string>,
+) {
+  const matches = Array.from(content.matchAll(COMMENT_MENTION_REGEX));
+
+  if (matches.length === 0) {
+    return content;
+  }
+
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+
+  matches.forEach((match, index) => {
+    const mentionText = match[0];
+    const username = match[1]?.toLowerCase() ?? "";
+    const start = match.index ?? 0;
+
+    if (start > cursor) {
+      nodes.push(content.slice(cursor, start));
+    }
+
+    if (validMentions.has(username)) {
+      nodes.push(
+        <span
+          className="rounded-full bg-blue-50 px-2 py-0.5 font-medium text-blue-700"
+          key={`${mentionText}-${index}`}
+        >
+          {mentionText}
+        </span>,
+      );
+    } else {
+      nodes.push(mentionText);
+    }
+
+    cursor = start + mentionText.length;
+  });
+
+  if (cursor < content.length) {
+    nodes.push(content.slice(cursor));
+  }
+
+  return nodes;
 }
 
 export function CommentComposer({
@@ -26,13 +79,58 @@ export function CommentComposer({
   onCancel,
   autoFocus = false,
   className,
+  teamMembers = [],
 }: CommentComposerProps) {
   const [content, setContent] = useState(initialValue);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [suggestions, setSuggestions] = useState<ProjectMemberUserSummary[]>([]);
+  const [mentions, setMentions] = useState<string[]>([]);
+
+  const validMentionSet = useMemo(
+    () =>
+      new Set(teamMembers.map((member) => member.username.toLowerCase())),
+    [teamMembers],
+  );
 
   useEffect(() => {
     setContent(initialValue);
-  }, [initialValue]);
+    setMentions(
+      extractMentionUsernames(initialValue).filter((username) =>
+        validMentionSet.has(username),
+      ),
+    );
+    setSuggestions([]);
+  }, [initialValue, validMentionSet]);
+
+  const handleChange = (value: string) => {
+    setContent(value);
+
+    const nextMentions = extractMentionUsernames(value).filter((username) =>
+      validMentionSet.has(username),
+    );
+    setMentions(nextMentions);
+
+    const keyword = findActiveMentionQuery(value);
+
+    if (keyword === null) {
+      setSuggestions([]);
+      return;
+    }
+
+    const filtered = teamMembers
+      .filter((member) =>
+        member.username.toLowerCase().includes(keyword),
+      )
+      .slice(0, 6);
+
+    setSuggestions(filtered);
+  };
+
+  const handleSelectUser = (member: ProjectMemberUserSummary) => {
+    const nextValue = replaceTrailingMention(content, member.username);
+    handleChange(nextValue);
+    setSuggestions([]);
+  };
 
   return (
     <form
@@ -56,15 +154,71 @@ export function CommentComposer({
     >
       <label className="flex flex-col gap-2">
         <span className="text-sm font-medium text-slate-700">{label}</span>
-        <textarea
-          autoFocus={autoFocus}
-          className="min-h-32 rounded-[24px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none focus:border-[color:var(--color-primary)] focus:ring-4 focus:ring-blue-100"
-          maxLength={MAX_COMMENT_LENGTH}
-          onChange={(event) => setContent(event.target.value)}
-          placeholder={placeholder}
-          value={content}
-        />
+        <div className="relative">
+          <textarea
+            autoFocus={autoFocus}
+            className="min-h-32 w-full rounded-[24px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none focus:border-[color:var(--color-primary)] focus:ring-4 focus:ring-blue-100"
+            maxLength={MAX_COMMENT_LENGTH}
+            onBlur={() => {
+              window.setTimeout(() => setSuggestions([]), 120);
+            }}
+            onChange={(event) => handleChange(event.target.value)}
+            onFocus={() => {
+              const keyword = findActiveMentionQuery(content);
+              if (keyword === null) {
+                return;
+              }
+
+              setSuggestions(
+                teamMembers
+                  .filter((member) =>
+                    member.username.toLowerCase().includes(keyword),
+                  )
+                  .slice(0, 6),
+              );
+            }}
+            placeholder={placeholder}
+            value={content}
+          />
+
+          {suggestions.length > 0 ? (
+            <div className="absolute left-0 right-0 top-[calc(100%+0.5rem)] z-20 overflow-hidden rounded-[24px] border border-slate-200 bg-white shadow-[0_20px_40px_-28px_rgba(15,23,42,0.35)]">
+              {suggestions.map((member) => (
+                <button
+                  className="flex w-full items-center justify-between gap-3 border-b border-slate-100 px-4 py-3 text-left text-sm last:border-b-0 hover:bg-slate-50"
+                  key={member.id}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    handleSelectUser(member);
+                  }}
+                  type="button"
+                >
+                  <span className="font-medium text-slate-900">
+                    {member.name}
+                  </span>
+                  <span className="text-slate-500">@{member.username}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
       </label>
+
+      {content.trim() ? (
+        <div className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+              Preview
+            </span>
+            <span className="text-xs text-slate-500">
+              {mentions.length} valid mention{mentions.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-600">
+            {renderMentionPreview(content, new Set(mentions))}
+          </p>
+        </div>
+      ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
         <Button loading={isSubmitting} type="submit">

--- a/components/issues/IssueDetailView.tsx
+++ b/components/issues/IssueDetailView.tsx
@@ -96,7 +96,10 @@ function relationTone(type: IssueRelationRecord["type"]) {
   }
 }
 
-function renderCommentContent(content: string) {
+function renderCommentContentWithValidation(
+  content: string,
+  validMentions: ReadonlySet<string>,
+) {
   const matches = Array.from(content.matchAll(COMMENT_MENTION_REGEX));
 
   if (matches.length === 0) {
@@ -114,14 +117,18 @@ function renderCommentContent(content: string) {
       nodes.push(content.slice(cursor, start));
     }
 
-    nodes.push(
-      <span
-        className="rounded-full bg-blue-50 px-2 py-0.5 font-medium text-blue-700"
-        key={`${mentionText}-${index}`}
-      >
-        {mentionText}
-      </span>,
-    );
+    if (validMentions.has((match[1] ?? "").toLowerCase())) {
+      nodes.push(
+        <span
+          className="rounded-full bg-blue-50 px-2 py-0.5 font-medium text-blue-700"
+          key={`${mentionText}-${index}`}
+        >
+          {mentionText}
+        </span>,
+      );
+    } else {
+      nodes.push(mentionText);
+    }
 
     cursor = start + mentionText.length;
   });
@@ -281,6 +288,9 @@ export function IssueDetailView({ issueId }: { issueId: string }) {
           ),
       )
     : [];
+  const validMentionUsernames = new Set(
+    detail?.teamMembers.map((member) => member.username.toLowerCase()) ?? [],
+  );
 
   return (
     <AppShell
@@ -624,6 +634,7 @@ export function IssueDetailView({ issueId }: { issueId: string }) {
                     });
                   }}
                   placeholder="Leave a clear handoff note, reproduction hint, or decision. Use @username to mention teammates."
+                  teamMembers={detail.teamMembers}
                 />
               )}
 
@@ -728,10 +739,14 @@ export function IssueDetailView({ issueId }: { issueId: string }) {
                               }
                             }}
                             submitLabel="Save changes"
+                            teamMembers={detail.teamMembers}
                           />
                         ) : (
                           <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-600">
-                            {renderCommentContent(comment.content)}
+                            {renderCommentContentWithValidation(
+                              comment.content,
+                              validMentionUsernames,
+                            )}
                           </p>
                         )}
                       </Card>

--- a/lib/comments.ts
+++ b/lib/comments.ts
@@ -1,6 +1,7 @@
 import { MAX_COMMENT_MENTIONS } from "@/lib/constants";
 
 export const COMMENT_MENTION_REGEX = /@([a-zA-Z0-9_]+)/g;
+const ACTIVE_MENTION_REGEX = /@([a-zA-Z0-9_]*)$/;
 
 export function extractMentionUsernames(content: string) {
   const usernames = new Set<string>();
@@ -20,4 +21,13 @@ export function extractMentionUsernames(content: string) {
   }
 
   return Array.from(usernames);
+}
+
+export function findActiveMentionQuery(content: string) {
+  const match = content.match(ACTIVE_MENTION_REGEX);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function replaceTrailingMention(content: string, username: string) {
+  return content.replace(ACTIVE_MENTION_REGEX, `@${username} `);
 }

--- a/services/comment-mentions-service.ts
+++ b/services/comment-mentions-service.ts
@@ -18,16 +18,11 @@ export async function resolveMentionedProjectMembers(
     return [];
   }
 
-  return client.projectMember.findMany({
+  const projectMembers = await client.projectMember.findMany({
     where: {
       projectId: input.projectId,
       userId: {
         not: input.actorUserId,
-      },
-      user: {
-        username: {
-          in: usernames,
-        },
       },
     },
     include: {
@@ -39,4 +34,10 @@ export async function resolveMentionedProjectMembers(
       },
     },
   });
+
+  const allowedUsernames = new Set(usernames);
+
+  return projectMembers.filter((member) =>
+    allowedUsernames.has(member.user.username.toLowerCase()),
+  );
 }

--- a/services/issues-service.ts
+++ b/services/issues-service.ts
@@ -139,7 +139,7 @@ async function resolveAssignee(
   });
 
   if (!assignee) {
-    throw notFound("Assignee not found.");
+    throw badRequest("Assignee must be a member of this project.");
   }
 
   if (


### PR DESCRIPTION
## Summary
- fix issue creation validation so assignees must submit as project member user IDs and invalid payloads return a clean 400
- add advanced comment mention UX with trailing `@` suggestions, valid mention highlighting, and safer frontend validation
- keep backend mention parsing project-scoped and deduplicated so notifications fire once for valid users only

## Verification
- `npm run lint`
- `npm run build`
- local API smoke test: invalid assignee -> `400`, valid issue create -> `201`, mention notification deduped to 1
- temporary Playwright browser smoke test: create issue UI succeeds, `@` suggestion/autocomplete works, valid mention preview highlights, comment submit returns `201`

## Notes
- no breaking API changes
- backend remains the source of truth for assignee validation and mention notification delivery